### PR TITLE
Tidy up imports

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -22,8 +22,12 @@ import threading
 import time
 
 from . import __version__, conf, selectdriver, structures, utils, world
-from .log import *
+from .log import log, PyLinkChannelLogger
 from .utils import ProtocolError  # Compatibility with PyLink 1.x
+
+__all__ = ['ChannelState', 'User', 'UserMapping', 'PyLinkNetworkCore',
+           'PyLinkNetworkCoreWithUtils', 'IRCNetwork', 'Server', 'Channel',
+           'PUIDGenerator']
 
 QUEUE_FULL = queue.Full
 

--- a/conf.py
+++ b/conf.py
@@ -17,6 +17,9 @@ from collections import defaultdict
 
 from . import world
 
+__all__ = ['ConfigurationError', 'conf', 'confname', 'validate', 'load_conf',
+           'get_database_name']
+
 
 class ConfigurationError(RuntimeError):
     """Error when config conditions aren't met."""

--- a/coremods/control.py
+++ b/coremods/control.py
@@ -4,13 +4,12 @@ control.py - Implements SHUTDOWN and REHASH functionality.
 import atexit
 import os
 import signal
-import sys
 import threading
 
 from pylinkirc import conf, utils, world  # Do not import classes, it'll import loop
 from pylinkirc.log import _get_console_log_level, _make_file_logger, _stop_file_loggers, log
 
-from . import login, permissions
+from . import login
 
 
 def remove_network(ircobj):

--- a/coremods/control.py
+++ b/coremods/control.py
@@ -11,6 +11,8 @@ from pylinkirc.log import _get_console_log_level, _make_file_logger, _stop_file_
 
 from . import login
 
+__all__ = ['remove_network', 'shutdown', 'rehash']
+
 
 def remove_network(ircobj):
     """Removes a network object from the pool."""

--- a/coremods/corecommands.py
+++ b/coremods/corecommands.py
@@ -3,13 +3,12 @@ corecommands.py - Implements core PyLink commands.
 """
 
 import gc
-import importlib
 import sys
 
-from pylinkirc import conf, utils, world
+from pylinkirc import utils, world
 from pylinkirc.log import log
 
-from . import control, login, permissions
+from . import control, permissions
 
 # Essential, core commands go here so that the "commands" plugin with less-important,
 # but still generic functions can be reloaded.

--- a/coremods/corecommands.py
+++ b/coremods/corecommands.py
@@ -10,6 +10,8 @@ from pylinkirc.log import log
 
 from . import control, permissions
 
+__all__ = []
+
 # Essential, core commands go here so that the "commands" plugin with less-important,
 # but still generic functions can be reloaded.
 

--- a/coremods/exttargets.py
+++ b/coremods/exttargets.py
@@ -5,6 +5,8 @@ exttargets.py - Implements extended targets like $account:xyz, $oper, etc.
 from pylinkirc import world
 from pylinkirc.log import log
 
+__all__ = []
+
 
 def bind(func):
     """

--- a/coremods/handlers.py
+++ b/coremods/handlers.py
@@ -6,6 +6,8 @@ import time
 from pylinkirc import conf, utils
 from pylinkirc.log import log
 
+__all__ = []
+
 
 def handle_whois(irc, source, command, args):
     """Handle WHOIS queries."""

--- a/coremods/login.py
+++ b/coremods/login.py
@@ -5,6 +5,9 @@ login.py - Implement core login abstraction.
 from pylinkirc import conf, utils
 from pylinkirc.log import log
 
+__all__ = ['pwd_context', 'check_login', 'verify_hash']
+
+
 # PyLink's global password context
 pwd_context = None
 

--- a/coremods/login.py
+++ b/coremods/login.py
@@ -2,7 +2,7 @@
 login.py - Implement core login abstraction.
 """
 
-from pylinkirc import conf, utils, world
+from pylinkirc import conf, utils
 from pylinkirc.log import log
 
 # PyLink's global password context

--- a/coremods/permissions.py
+++ b/coremods/permissions.py
@@ -7,6 +7,9 @@ from collections import defaultdict
 from pylinkirc import conf, utils
 from pylinkirc.log import log
 
+__all__ = ['default_permissions', 'add_default_permissions',
+           'remove_default_permissions', 'check_permissions']
+
 # Global variables: these store mappings of hostmasks/exttargets to lists of permissions each target has.
 default_permissions = defaultdict(set)
 

--- a/coremods/permissions.py
+++ b/coremods/permissions.py
@@ -2,7 +2,6 @@
 permissions.py - Permissions Abstraction for PyLink IRC Services.
 """
 
-import threading
 from collections import defaultdict
 
 from pylinkirc import conf, utils

--- a/coremods/service_support.py
+++ b/coremods/service_support.py
@@ -5,6 +5,8 @@ service_support.py - Implements handlers for the PyLink ServiceBot API.
 from pylinkirc import conf, utils, world
 from pylinkirc.log import log
 
+__all__ = []
+
 
 def spawn_service(irc, source, command, args):
     """Handles new service bot introductions."""

--- a/log.py
+++ b/log.py
@@ -12,6 +12,8 @@ import os
 
 from . import conf, world
 
+__all__ = ['log']
+
 # Stores a list of active file loggers.
 fileloggers = []
 

--- a/plugins/antispam.py
+++ b/plugins/antispam.py
@@ -1,6 +1,6 @@
 # antispam.py: Basic services-side spamfilters for IRC
 
-from pylinkirc import conf, utils, world
+from pylinkirc import conf, utils
 from pylinkirc.log import log
 
 mydesc = ("Provides anti-spam functionality.")

--- a/plugins/bots.py
+++ b/plugins/bots.py
@@ -4,7 +4,6 @@ with things.
 """
 from pylinkirc import utils
 from pylinkirc.coremods import permissions
-from pylinkirc.log import log
 
 
 @utils.add_cmd

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -5,7 +5,6 @@ import time
 from pylinkirc import __version__, conf, real_version, utils, world
 from pylinkirc.coremods import permissions
 from pylinkirc.coremods.login import pwd_context
-from pylinkirc.log import log
 
 default_permissions = {"*!*@*": ['commands.status', 'commands.showuser', 'commands.showchan', 'commands.shownet']}
 

--- a/plugins/exec.py
+++ b/plugins/exec.py
@@ -1,13 +1,10 @@
 """
 exec.py: Provides commands for executing raw code and debugging PyLink.
 """
-import importlib
 import pprint
 # These imports are not strictly necessary, but make the following modules
 # easier to access through eval and exec.
-import re
 import threading
-import time
 
 from pylinkirc import utils, world
 from pylinkirc.coremods import permissions

--- a/plugins/exec.py
+++ b/plugins/exec.py
@@ -9,8 +9,7 @@ import re
 import threading
 import time
 
-import pylinkirc
-from pylinkirc import *
+from pylinkirc import utils, world
 from pylinkirc.coremods import permissions
 from pylinkirc.log import log
 

--- a/plugins/games.py
+++ b/plugins/games.py
@@ -4,7 +4,6 @@ games.py: Creates a bot providing a few simple games.
 import random
 
 from pylinkirc import utils
-from pylinkirc.log import log
 
 mydesc = "The \x02Games\x02 plugin provides simple games for IRC."
 

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -7,10 +7,11 @@ clientbot.py: Clientbot (regular IRC bot) protocol module for PyLink.
 # works on most networks though!
 
 import base64
+import string
 import threading
 import time
 
-from pylinkirc import conf, utils
+from pylinkirc import conf, utils, world
 from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -16,6 +16,8 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *
 
+__all__ = ['ClientbotBaseProtocol', 'ClientbotWrapperProtocol']
+
 FALLBACK_REALNAME = 'PyLink Relay Mirror Client'
 
 # IRCv3 capabilities to request when available

--- a/protocols/clientbot.py
+++ b/protocols/clientbot.py
@@ -11,7 +11,7 @@ import string
 import threading
 import time
 
-from pylinkirc import conf, utils, world
+from pylinkirc import utils, world
 from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -4,7 +4,7 @@ hybrid.py: IRCD-Hybrid protocol module for PyLink.
 
 import time
 
-from pylinkirc import conf, utils
+from pylinkirc import conf
 from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ts6 import *

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -7,7 +7,7 @@ import time
 from pylinkirc import conf
 from pylinkirc.classes import *
 from pylinkirc.log import log
-from pylinkirc.protocols.ts6 import *
+from pylinkirc.protocols.ts6 import TS6Protocol
 
 __all__ = ['HybridProtocol']
 

--- a/protocols/hybrid.py
+++ b/protocols/hybrid.py
@@ -9,6 +9,8 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ts6 import *
 
+__all__ = ['HybridProtocol']
+
 
 # This protocol module inherits from the TS6 protocol.
 class HybridProtocol(TS6Protocol):

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -5,7 +5,7 @@ inspircd.py: InspIRCd 2.0, 3.x protocol module for PyLink.
 import threading
 import time
 
-from pylinkirc import conf, utils
+from pylinkirc import conf
 from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ts6_common import *

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -10,6 +10,8 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ts6_common import *
 
+__all__ = ['InspIRCdProtocol']
+
 
 class InspIRCdProtocol(TS6BaseProtocol):
 

--- a/protocols/inspircd.py
+++ b/protocols/inspircd.py
@@ -8,7 +8,7 @@ import time
 from pylinkirc import conf
 from pylinkirc.classes import *
 from pylinkirc.log import log
-from pylinkirc.protocols.ts6_common import *
+from pylinkirc.protocols.ts6_common import TS6BaseProtocol
 
 __all__ = ['InspIRCdProtocol']
 

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -4,9 +4,8 @@ ircs2s_common.py: Common base protocol class with functions shared by TS6 and P1
 
 import re
 import time
-from collections import defaultdict
 
-from pylinkirc import conf, utils
+from pylinkirc import conf
 from pylinkirc.classes import IRCNetwork, ProtocolError
 from pylinkirc.log import log
 

--- a/protocols/ircs2s_common.py
+++ b/protocols/ircs2s_common.py
@@ -10,6 +10,8 @@ from pylinkirc import conf, utils
 from pylinkirc.classes import IRCNetwork, ProtocolError
 from pylinkirc.log import log
 
+__all__ = ['IncrementalUIDGenerator', 'IRCCommonProtocol', 'IRCS2SProtocol']
+
 
 class IncrementalUIDGenerator():
     """

--- a/protocols/nefarious.py
+++ b/protocols/nefarious.py
@@ -5,6 +5,8 @@ nefarious.py: Migration stub to the new P10 protocol module.
 from pylinkirc.log import log
 from pylinkirc.protocols.p10 import *
 
+__all__ = ['NefariousProtocol']
+
 
 class NefariousProtocol(P10Protocol):
     def __init__(self, *args, **kwargs):

--- a/protocols/nefarious.py
+++ b/protocols/nefarious.py
@@ -3,7 +3,7 @@ nefarious.py: Migration stub to the new P10 protocol module.
 """
 
 from pylinkirc.log import log
-from pylinkirc.protocols.p10 import *
+from pylinkirc.protocols.p10 import P10Protocol
 
 __all__ = ['NefariousProtocol']
 

--- a/protocols/ngircd.py
+++ b/protocols/ngircd.py
@@ -15,6 +15,8 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *
 
+__all__ = ['NgIRCdProtocol']
+
 
 class NgIRCdProtocol(IRCS2SProtocol):
     def __init__(self, irc):

--- a/protocols/p10.py
+++ b/protocols/p10.py
@@ -3,6 +3,7 @@ p10.py: P10 protocol module for PyLink, supporting Nefarious IRCu and others.
 """
 
 import base64
+import socket
 import struct
 import time
 from ipaddress import ip_address
@@ -11,6 +12,8 @@ from pylinkirc import conf, structures, utils
 from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *
+
+__all__ = ['P10Protocol']
 
 
 class P10UIDGenerator(IncrementalUIDGenerator):

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -10,6 +10,8 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ts6_common import *
 
+__all__ = ['TS6Protocol']
+
 
 class TS6Protocol(TS6BaseProtocol):
 

--- a/protocols/ts6.py
+++ b/protocols/ts6.py
@@ -8,7 +8,7 @@ import time
 from pylinkirc import conf, utils
 from pylinkirc.classes import *
 from pylinkirc.log import log
-from pylinkirc.protocols.ts6_common import *
+from pylinkirc.protocols.ts6_common import TS6BaseProtocol
 
 __all__ = ['TS6Protocol']
 

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -5,7 +5,7 @@ ts6_common.py: Common base protocol class with functions shared by the UnrealIRC
 import string
 import time
 
-from pylinkirc import conf, structures, utils
+from pylinkirc import conf, structures
 from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *

--- a/protocols/ts6_common.py
+++ b/protocols/ts6_common.py
@@ -10,6 +10,8 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ircs2s_common import *
 
+__all__ = ['TS6BaseProtocol']
+
 
 class TS6SIDGenerator():
     """

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -10,7 +10,7 @@ import time
 from pylinkirc import conf, utils
 from pylinkirc.classes import *
 from pylinkirc.log import log
-from pylinkirc.protocols.ts6_common import *
+from pylinkirc.protocols.ts6_common import TS6BaseProtocol
 
 __all__ = ['UnrealProtocol']
 

--- a/protocols/unreal.py
+++ b/protocols/unreal.py
@@ -12,6 +12,9 @@ from pylinkirc.classes import *
 from pylinkirc.log import log
 from pylinkirc.protocols.ts6_common import *
 
+__all__ = ['UnrealProtocol']
+
+
 SJOIN_PREFIXES = {'q': '*', 'a': '~', 'o': '@', 'h': '%', 'v': '+', 'b': '&', 'e': '"', 'I': "'"}
 
 class UnrealProtocol(TS6BaseProtocol):

--- a/selectdriver.py
+++ b/selectdriver.py
@@ -9,6 +9,9 @@ import threading
 from pylinkirc import world
 from pylinkirc.log import log
 
+__all__ = ['register', 'unregister', 'start']
+
+
 SELECT_TIMEOUT = 0.5
 
 selector = selectors.DefaultSelector()

--- a/structures.py
+++ b/structures.py
@@ -16,6 +16,13 @@ from copy import copy, deepcopy
 from . import conf
 from .log import log
 
+__all__ = ['KeyedDefaultdict', 'CopyWrapper', 'CaseInsensitiveFixedSet',
+          'CaseInsensitiveDict', 'IRCCaseInsensitiveDict',
+          'CaseInsensitiveSet', 'IRCCaseInsensitiveSet',
+          'CamelCaseToSnakeCase', 'DataStore', 'JSONDataStore',
+          'PickleDataStore']
+
+
 _BLACKLISTED_COPY_TYPES = []
 
 class KeyedDefaultdict(collections.defaultdict):

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,15 @@ from pylinkirc import plugins, protocols
 from . import conf, structures, world
 from .log import log
 
+__all__ = ['PLUGIN_PREFIX', 'PROTOCOL_PREFIX', 'NORMALIZEWHITESPACE_RE',
+           'NotAuthorizedError', 'InvalidArgumentsError', 'ProtocolError',
+           'add_cmd', 'add_hook', 'expand_path', 'split_hostmask',
+           'ServiceBot', 'register_service', 'unregister_service',
+           'wrap_arguments', 'IRCParser', 'strip_irc_formatting',
+           'remove_range', 'get_hostname_type', 'parse_duration', 'match_text',
+           'merge_iterables']
+
+
 PLUGIN_PREFIX = plugins.__name__ + '.'
 PROTOCOL_PREFIX = protocols.__name__ + '.'
 NORMALIZEWHITESPACE_RE = re.compile(r'\s+')

--- a/world.py
+++ b/world.py
@@ -6,6 +6,10 @@ import threading
 import time
 from collections import defaultdict, deque
 
+__all__ = ['testing', 'hooks', 'networkobjects', 'plugins', 'services',
+           'exttarget_handlers', 'started', 'start_ts', 'shutting_down',
+           'source', 'fallback_hostname', 'daemon']
+
 # This indicates whether we're running in tests mode. What it actually does
 # though is control whether IRC connections should be threaded or not.
 testing = False


### PR DESCRIPTION
Define `__all__` for the modules that are imported * from. Also remove the unneeded imports.

I tested what I could and `pylint` no longer complain about imports. But further testing would be welcome.